### PR TITLE
Bugfix/spa fallback controller

### DIFF
--- a/backend-springboot/src/main/java/com/cscd488seniorproject/syllabussyncproject/SpaController.java
+++ b/backend-springboot/src/main/java/com/cscd488seniorproject/syllabussyncproject/SpaController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class SpaController {
 
     // This fowards all non "/api" requests to index.html so that the vue router can handle the routing on the frontend
-    @RequestMapping(value = {"/{path:^(?!api).*$}", "/**/{path:^(?!api).*$}"})
+    @RequestMapping(value = { "/{path:[^\\.]*}", "/**/{path:[^\\.]*}"})
     public String foward() {
         return "forward:/index.html";
     }

--- a/backend-springboot/src/main/java/com/cscd488seniorproject/syllabussyncproject/SpaController.java
+++ b/backend-springboot/src/main/java/com/cscd488seniorproject/syllabussyncproject/SpaController.java
@@ -1,0 +1,15 @@
+package com.cscd488seniorproject.syllabussyncproject;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+
+@Controller
+public class SpaController {
+
+    // This fowards all non "/api" requests to index.html so that the vue router can handle the routing on the frontend
+    @RequestMapping(value = {"/{path:^(?!api).*$}", "/**/{path:^(?!api).*$}"})
+    public String foward() {
+        return "forward:/index.html";
+    }
+}


### PR DESCRIPTION
This SPA controller was needed as each time we refreshed on our website, it would give a 404. Since our vue frontend manages the application's routing using the browser's native URL API, we have to have a controller that ignores urls like /api/ and sends those files to index.html.