### PR TITLE
Workload Projections Feature

### DIFF
--- a/frontend-vue/src/components/Sidebar.vue
+++ b/frontend-vue/src/components/Sidebar.vue
@@ -24,6 +24,7 @@ const links = computed(() => {
       { to: "/app/meetings", label: "Meeting Times" },
       { to: "/app/calendar", label: "Calendar" },
       { to: "/app/syllabus-upload", label: "Syllabus Upload" },
+      { to: "/app/workload-projections", label: "Workload Projections" },
     ];
   }
 
@@ -33,6 +34,7 @@ const links = computed(() => {
       { to: "/app/classes", label: "My Classes" },
       { to: "/app/meetings", label: "Meeting Times" },
       { to: "/app/calendar", label: "Calendar" },
+      { to: "/app/workload-projections", label: "Workload Projections" },
     ];
   }
 
@@ -42,6 +44,7 @@ const links = computed(() => {
     { to: "/app/classes", label: "My Classes" },
     { to: "/app/meetings", label: "Meeting Times" },
     { to: "/app/calendar", label: "Calendar" },
+    { to: "/app/workload-projections", label: "Workload Projections" },
     { to: "/app/office-hours", label: "Office Hours Match" },
   ];
 });

--- a/frontend-vue/src/router/index.js
+++ b/frontend-vue/src/router/index.js
@@ -9,6 +9,7 @@ import DashboardLayout from "../layout/DashboardLayout.vue";
 import Calendar from "../views/Calendar.vue";
 import OfficeHours from "../views/OfficeHours.vue";
 import SyllabusUpload from "../views/SyllabusUpload.vue";
+import WorkloadProjections from "../views/WorkloadProjections.vue";
 import MyClasses from "../views/MyClasses.vue";
 import ClassDetails from "../views/ClassDetails.vue";
 
@@ -30,6 +31,7 @@ const router = createRouter({
         { path: "calendar", name: "calendar", component: Calendar },
         { path: "office-hours", name: "office-hours", component: OfficeHours },
         { path: "syllabus-upload", name: "syllabus-upload", component: SyllabusUpload },
+        { path: "workload-projections", name: "workload-projections", component: WorkloadProjections },
         { path: "profile", name: "profile", component: Profile, meta: { hideHeader: true } },
       ],
     },

--- a/frontend-vue/src/utils/workload.js
+++ b/frontend-vue/src/utils/workload.js
@@ -4,6 +4,10 @@ This helps keep workload related logic in its own module, which can be used by
 multiple components
  */
 
+
+/* Parses a local date-time string (e.g. "2024-09-15T14:30") into a Date object.
+* This is used to handle date-time strings for workload Items
+*/
 export function parseLocalDateTime(s) {
   if (!s) return new Date(NaN);
   const [datePart, timePart = "00:00:00"] = String(s).split("T");
@@ -13,13 +17,21 @@ export function parseLocalDateTime(s) {
   return new Date(y, (m || 1) - 1, d || 1, Number(hh || 0), Number(mm || 0), Number(ss || 0));
 }
 
+/*
+* Returns the start of the week (Sunday) for a given date.
+* If no date is provided, uses the current date.
+*/
 export function startOfWeekSunday(d = new Date()) {
   const out = new Date(d);
-  out.setHours(0, 0, 0, 0);
+  out.setHours(0, 0, 0, 0); 
   out.setDate(out.getDate() - out.getDay()); // Sunday=0
   return out;
 }
 
+/**
+ * Returns the end of the week (Saturday) for a given date.
+ * If no date is provided, uses the current date.
+ */
 export function endOfWeekSaturday(d = new Date()) {
   const start = startOfWeekSunday(d);
   const out = new Date(start);
@@ -28,36 +40,25 @@ export function endOfWeekSaturday(d = new Date()) {
   return out;
 }
 
+/* Adds a specified number of days to a date and returns the new date.
+* This is used to calculate week ranges for workload projections.
+*/
 export function addDays(d, days) {
   const out = new Date(d);
   out.setDate(out.getDate() + days);
   return out;
 }
 
-export function isLikelyWorkloadItem(summary) {
-  const s = String(summary || "").toLowerCase();
-  if (!s) return false;
-  return (
-    s.includes("due") ||
-    s.includes("assignment") ||
-    s.match(/\bhw\b/) ||
-    s.includes("homework") ||
-    s.includes("quiz") ||
-    s.includes("exam") ||
-    s.includes("midterm") ||
-    s.includes("final") ||
-    s.includes("project") ||
-    s.includes("lab") ||
-    s.includes("discussion")
-  );
-}
-
+/* Checks if the count of due items falls into light, moderate, or heavy workload levels.*/
 export function workloadLevelFromCount(count) {
   if (count >= 6) return "heavy";
   if (count >= 3) return "moderate";
   return "light";
 }
 
+/* Extracts a course code (e.g. "CSCD350") from a calendar event summary string.
+* This is used to link calendar events to specific classes for workload analysis.
+*/
 export function extractCourseCodeFromSummary(summary) {
   const s = String(summary || "");
   // Common patterns: CSCD350, CSCD 350, CSCD-350
@@ -66,6 +67,11 @@ export function extractCourseCodeFromSummary(summary) {
   return `${m[1]}${m[2]}`.toUpperCase();
 }
 
+/* Attempts to match a calendar event summary to one of the user's class codes.
+* This is used to link calendar events to specific classes for workload analysis.
+* THIS IS A VERY IMPORTANT FUNCTION
+* It will first look for direct matches (which is really unlikely to work), then looks for type-based matches
+*/
 export function matchEventToClassCode(summary, myClasses) {
   const s = String(summary || "").toUpperCase();
   if (!s) return null;
@@ -84,19 +90,12 @@ export function matchEventToClassCode(summary, myClasses) {
   return extractCourseCodeFromSummary(summary);
 }
 
-export function parsePercent(weightStr) {
-  const raw = String(weightStr || "").trim();
-  if (!raw) return null;
-  const m = raw.match(/(-?\d+(?:\.\d+)?)\s*%/);
-  if (m) return Number(m[1]);
-  const n = Number(raw);
-  if (Number.isFinite(n)) {
-    if (n > 0 && n <= 1) return n * 100;
-    return n;
-  }
-  return null;
-}
-
+/* This const defines synonyms for different types of coursework (e.g. "assignment", "quiz", "exam") to help
+* match calendar events to grade breakdown components, even if the wording is different.
+* For example, an event with "HW1" in the summary could be matched to a
+* grade breakdown component labeled "Homework 1" because "hw" is a recognized synonym for "homework".
+* This improves the accuracy of linking calendar events to their corresponding grade components for workload analysis. 
+*/
 const TYPE_SYNONYMS = {
   assignment: ["assignment", "assignments", "hw", "homework"],
   quiz: ["quiz", "quizzes"],
@@ -107,6 +106,10 @@ const TYPE_SYNONYMS = {
   reading: ["reading", "read"],
 };
 
+/* Normalizes a string by converting it to lowercase, removing special characters, and collapsing whitespace.
+* This is used to improve the robustness of matching calendar event summaries to grade breakdown components,
+* by reducing variations in formatting and wording.
+*/
 function norm(s) {
   return String(s || "")
     .toLowerCase()
@@ -115,6 +118,13 @@ function norm(s) {
     .trim();
 }
 
+/* This is the big boy function that tries to match a calendar event summary to a grade breakdown component, using multiple strategies:
+1) Direct component name match: checks if the normalized event summary includes the normalized component name.
+2) Type-based match: detects if the event summary contains keywords associated with a coursework type (e.g. "hw" for homework),
+ and then checks if any component names include synonyms for that type.
+3) If there is exactly one component in the grade breakdown, it assumes that is the match.
+This function is crucial for linking calendar events to their corresponding grade components
+*/
 export function matchGradeBreakdownComponent(eventSummary, gradeBreakdown) {
   const s = norm(eventSummary);
   const list = Array.isArray(gradeBreakdown) ? gradeBreakdown : [];

--- a/frontend-vue/src/utils/workload.js
+++ b/frontend-vue/src/utils/workload.js
@@ -1,0 +1,161 @@
+/* This js file contains utility functions for parsing
+and analyzing workload data, to help with vue pages like WorkloadProjections.vue.
+This helps keep workload related logic in its own module, which can be used by
+multiple components
+ */
+
+export function parseLocalDateTime(s) {
+  if (!s) return new Date(NaN);
+  const [datePart, timePart = "00:00:00"] = String(s).split("T");
+  const [y, m, d] = datePart.split("-").map(Number);
+  const [hh, mm, ssRaw] = timePart.split(":");
+  const ss = (ssRaw || "0").split(".")[0];
+  return new Date(y, (m || 1) - 1, d || 1, Number(hh || 0), Number(mm || 0), Number(ss || 0));
+}
+
+export function startOfWeekSunday(d = new Date()) {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  out.setDate(out.getDate() - out.getDay()); // Sunday=0
+  return out;
+}
+
+export function endOfWeekSaturday(d = new Date()) {
+  const start = startOfWeekSunday(d);
+  const out = new Date(start);
+  out.setDate(start.getDate() + 6);
+  out.setHours(23, 59, 59, 999);
+  return out;
+}
+
+export function addDays(d, days) {
+  const out = new Date(d);
+  out.setDate(out.getDate() + days);
+  return out;
+}
+
+export function isLikelyWorkloadItem(summary) {
+  const s = String(summary || "").toLowerCase();
+  if (!s) return false;
+  return (
+    s.includes("due") ||
+    s.includes("assignment") ||
+    s.match(/\bhw\b/) ||
+    s.includes("homework") ||
+    s.includes("quiz") ||
+    s.includes("exam") ||
+    s.includes("midterm") ||
+    s.includes("final") ||
+    s.includes("project") ||
+    s.includes("lab") ||
+    s.includes("discussion")
+  );
+}
+
+export function workloadLevelFromCount(count) {
+  if (count >= 6) return "heavy";
+  if (count >= 3) return "moderate";
+  return "light";
+}
+
+export function extractCourseCodeFromSummary(summary) {
+  const s = String(summary || "");
+  // Common patterns: CSCD350, CSCD 350, CSCD-350
+  const m = s.match(/\b([A-Za-z]{2,6})\s?-?\s?(\d{3,4})\b/);
+  if (!m) return null;
+  return `${m[1]}${m[2]}`.toUpperCase();
+}
+
+export function matchEventToClassCode(summary, myClasses) {
+  const s = String(summary || "").toUpperCase();
+  if (!s) return null;
+
+  const candidates = (myClasses || [])
+    .map((c) => String(c?.classCode || "").toUpperCase())
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+
+  for (const code of candidates) {
+    if (s.includes(code)) return code;
+    const spaced = code.replace(/^(\D+)(\d+)/, "$1 $2");
+    if (spaced !== code && s.includes(spaced)) return code;
+  }
+
+  return extractCourseCodeFromSummary(summary);
+}
+
+export function parsePercent(weightStr) {
+  const raw = String(weightStr || "").trim();
+  if (!raw) return null;
+  const m = raw.match(/(-?\d+(?:\.\d+)?)\s*%/);
+  if (m) return Number(m[1]);
+  const n = Number(raw);
+  if (Number.isFinite(n)) {
+    if (n > 0 && n <= 1) return n * 100;
+    return n;
+  }
+  return null;
+}
+
+const TYPE_SYNONYMS = {
+  assignment: ["assignment", "assignments", "hw", "homework"],
+  quiz: ["quiz", "quizzes"],
+  exam: ["exam", "midterm", "final", "test"],
+  project: ["project", "milestone"],
+  lab: ["lab", "labs"],
+  discussion: ["discussion", "discussion post"],
+  reading: ["reading", "read"],
+};
+
+function norm(s) {
+  return String(s || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9%\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function matchGradeBreakdownComponent(eventSummary, gradeBreakdown) {
+  const s = norm(eventSummary);
+  const list = Array.isArray(gradeBreakdown) ? gradeBreakdown : [];
+  if (!s || !list.length) return null;
+
+  // 1) direct component name match
+  for (const item of list) {
+    const comp = norm(item?.component);
+    if (comp && s.includes(comp)) return item;
+  }
+
+  // 2) type-based match to a component
+  let detectedType = null;
+  for (const [t, words] of Object.entries(TYPE_SYNONYMS)) {
+    for (const w of words) {
+      if (w === "hw") {
+        if (s.match(/\bhw\b/)) {
+          detectedType = t;
+          break;
+        }
+      } else if (s.includes(w)) {
+        detectedType = t;
+        break;
+      }
+    }
+    if (detectedType) break;
+  }
+
+  if (detectedType) {
+    const synonyms = TYPE_SYNONYMS[detectedType] || [];
+    for (const item of list) {
+      const comp = norm(item?.component);
+      if (!comp) continue;
+      if (synonyms.some((w) => (w === "hw" ? comp.match(/\bhw\b/) : comp.includes(w)))) {
+        return item;
+      }
+    }
+  }
+
+  // 3) if exactly one component, assume it
+  if (list.length === 1) return list[0];
+
+  return null;
+}

--- a/frontend-vue/src/views/Dashboard.vue
+++ b/frontend-vue/src/views/Dashboard.vue
@@ -4,7 +4,6 @@ import { useRouter } from "vue-router";
 
 import {
   endOfWeekSaturday,
-  isLikelyWorkloadItem,
   parseLocalDateTime,
   startOfWeekSunday,
   workloadLevelFromCount,
@@ -136,7 +135,6 @@ const assignmentsThisWeek = computed(() => {
   const end = weekEnd.value;
   return events.value.filter((e) => {
     if (e.isCancelled) return false;
-    if (!isLikelyWorkloadItem(e.summary)) return false;
     const dt = parseLocalDateTime(e.startAt);
     return dt >= start && dt <= end;
   });

--- a/frontend-vue/src/views/Dashboard.vue
+++ b/frontend-vue/src/views/Dashboard.vue
@@ -2,6 +2,14 @@
 import { computed, inject, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 
+import {
+  endOfWeekSaturday,
+  isLikelyWorkloadItem,
+  parseLocalDateTime,
+  startOfWeekSunday,
+  workloadLevelFromCount,
+} from "../utils/workload";
+
 const me = inject("me", null);
 const router = useRouter();
 
@@ -83,10 +91,8 @@ const hasEvents = computed(() => events.value.length > 0);
 
 const upcomingItems = computed(() => {
   const now = new Date();
-  // End of current week Sunday 23:59:59
-  const endOfWeek = new Date(now);
-  endOfWeek.setDate(now.getDate() + (7 - now.getDay()));
-  endOfWeek.setHours(23, 59, 59, 999);
+  // End of current week Saturday 23:59:59 (Sunday–Saturday week)
+  const endOfWeek = endOfWeekSaturday(now);
 
   return events.value
     .filter(e => {
@@ -121,14 +127,24 @@ async function fetchEvents() {
   }
 }
 
-function parseLocalDateTime(s) {
-  if (!s) return new Date(NaN);
-  const [datePart, timePart = "00:00:00"] = String(s).split("T");
-  const [y, m, d] = datePart.split("-").map(Number);
-  const [hh, mm, ssRaw] = timePart.split(":");
-  const ss = (ssRaw || "0").split(".")[0];
-  return new Date(y, m - 1, d, Number(hh || 0), Number(mm || 0), Number(ss || 0));
-}
+// ── Workload This Week (overall Sun–Sat) ──────────────────────────
+const weekStart = computed(() => startOfWeekSunday(new Date()));
+const weekEnd = computed(() => endOfWeekSaturday(new Date()));
+
+const assignmentsThisWeek = computed(() => {
+  const start = weekStart.value;
+  const end = weekEnd.value;
+  return events.value.filter((e) => {
+    if (e.isCancelled) return false;
+    if (!isLikelyWorkloadItem(e.summary)) return false;
+    const dt = parseLocalDateTime(e.startAt);
+    return dt >= start && dt <= end;
+  });
+});
+
+const assignmentCountThisWeek = computed(() => assignmentsThisWeek.value.length);
+const workloadLevelThisWeek = computed(() => workloadLevelFromCount(assignmentCountThisWeek.value));
+const workloadMeterWidth = computed(() => Math.min(100, (assignmentCountThisWeek.value / 8) * 100));
 
 onMounted(async () => {
   await fetchMyClasses();
@@ -272,7 +288,9 @@ onMounted(async () => {
         <div class="card-header">
           <div>
             <h2>Workload This Week</h2>
+            <p class="muted" style="margin:6px 0 0">{{ assignmentCountThisWeek }} assignment(s) due (Sun–Sat).</p>
           </div>
+          <button class="btn ghost" @click="router.push('/app/workload-projections')">Details</button>
         </div>
 
         <div class="workload-scale">
@@ -282,11 +300,11 @@ onMounted(async () => {
         </div>
 
         <div class="workload-meter" aria-hidden="true">
-          <div class="workload-meter-fill heavy" style="width: 70%"></div>
+          <div class="workload-meter-fill" :class="workloadLevelThisWeek" :style="{ width: workloadMeterWidth + '%' }"></div>
         </div>
 
         <div class="empty-note">
-          Placeholder for a workload summary (e.g., readings, assignments, quizzes).
+          {{ assignmentCountThisWeek ? `Workload level: ${workloadLevelThisWeek}.` : (hasEvents ? 'No due assignments detected this week.' : 'No Canvas feed connected yet.') }}
         </div>
       </section>
     </div>
@@ -365,6 +383,22 @@ onMounted(async () => {
     90deg,
     rgba(239, 68, 68, 0.65),
     rgba(239, 68, 68, 0.25)
+  );
+}
+
+.workload-meter-fill.moderate {
+  background: linear-gradient(
+    90deg,
+    rgba(245, 158, 11, 0.65),
+    rgba(245, 158, 11, 0.25)
+  );
+}
+
+.workload-meter-fill.light {
+  background: linear-gradient(
+    90deg,
+    rgba(34, 197, 94, 0.65),
+    rgba(34, 197, 94, 0.25)
   );
 }
 

--- a/frontend-vue/src/views/Dashboard.vue
+++ b/frontend-vue/src/views/Dashboard.vue
@@ -281,14 +281,14 @@ onMounted(async () => {
         </div>
       </section>
 
-      <!-- Workload This Week (placeholder) -->
+      <!-- Workload This Week  -->
       <section class="card">
         <div class="card-header">
           <div>
             <h2>Workload This Week</h2>
             <p class="muted" style="margin:6px 0 0">{{ assignmentCountThisWeek }} assignment(s) due (Sun–Sat).</p>
           </div>
-          <button class="btn ghost" @click="router.push('/app/workload-projections')">Details</button>
+          <button class="btn" @click="router.push('/app/workload-projections')">Details</button>
         </div>
 
         <div class="workload-scale">
@@ -301,8 +301,8 @@ onMounted(async () => {
           <div class="workload-meter-fill" :class="workloadLevelThisWeek" :style="{ width: workloadMeterWidth + '%' }"></div>
         </div>
 
-        <div class="empty-note">
-          {{ assignmentCountThisWeek ? `Workload level: ${workloadLevelThisWeek}.` : (hasEvents ? 'No due assignments detected this week.' : 'No Canvas feed connected yet.') }}
+        <div v-if="!assignmentCountThisWeek" class="empty-note">
+          {{ hasEvents ? 'No due assignments detected this week.' : 'No Canvas feed connected yet.' }}
         </div>
       </section>
     </div>
@@ -323,17 +323,12 @@ onMounted(async () => {
   gap: 18px;
 }
 
-.workload-scale {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 10px;
-}
+ /* Pill component for workload levels */
 
 .pill {
   display: inline-flex;
   align-items: center;
-  padding: 6px 10px;
+  padding: 10px 10px;
   border-radius: 999px;
   font-size: 12px;
   font-weight: 900;
@@ -361,8 +356,17 @@ onMounted(async () => {
   color: rgba(187, 247, 208, 0.95);
 }
 
+/* css for workload meter */
+
+.workload-scale {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
 .workload-meter {
-  height: 12px;
+  height: 14px;
   border-radius: 999px;
   background: rgba(255,255,255,0.05);
   border: 1px solid rgba(255,255,255,0.08);
@@ -399,6 +403,8 @@ onMounted(async () => {
     rgba(34, 197, 94, 0.25)
   );
 }
+
+/* Class schedule grid */
 
 .prof {
   display: flex;
@@ -594,7 +600,6 @@ h3 {
   font-weight: 800;
 }
 
-
 .row {
   margin-top: 12px;
   display: flex;
@@ -618,18 +623,23 @@ h3 {
 
 .class-select {
   font-size: 13px;
-  padding: 6px 10px;
-  border-radius: 10px;
-  border: 1px solid rgba(255,255,255,0.10);
-  background: rgba(255,255,255,0.04);
-  color: #e5e7eb;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: none;
+  background: #2563eb;
+  color: white;
+  font-weight: 900;
   outline: none;
   cursor: pointer;
   flex-shrink: 0;
 }
 
+.class-select:hover {
+  background: #1d4ed8;
+}
+
 .class-select:focus {
-  border-color: #2563eb;
+  box-shadow: 0 0 0 2px rgba(37,99,235,0.5);
 }
 
 .syllabus-section {

--- a/frontend-vue/src/views/WorkloadProjections.vue
+++ b/frontend-vue/src/views/WorkloadProjections.vue
@@ -1,0 +1,516 @@
+<script setup>
+import { computed, onMounted, reactive, ref } from "vue";
+
+import {
+  addDays,
+  endOfWeekSaturday,
+  matchEventToClassCode,
+  matchGradeBreakdownComponent,
+  parseLocalDateTime,
+  startOfWeekSunday,
+  workloadLevelFromCount,
+} from "../utils/workload";
+
+const loading = ref(false);
+const error = ref("");
+
+const myClasses = ref([]);
+const events = ref([]);
+
+const weekIndex = ref(0); // 0 = this week
+
+// toggle state per joinCode
+const open = reactive({});
+
+const syllabusCache = ref(new Map()); // joinCode -> syllabusObject|null
+
+async function fetchMyClasses() {
+  const res = await fetch("/api/classes/mine", { credentials: "include" });
+  if (!res.ok) throw new Error("Failed to load classes");
+  myClasses.value = await res.json();
+}
+
+async function fetchEvents() {
+  const res = await fetch("/api/calendar/events", { credentials: "include" });
+  if (!res.ok) throw new Error("Failed to load calendar events");
+  events.value = await res.json();
+}
+
+async function fetchSyllabusIfNeeded(joinCode) {
+  if (!joinCode) return;
+  if (syllabusCache.value.has(joinCode)) return;
+
+  const res = await fetch(`/api/courses/${joinCode}/syllabus`, { credentials: "include" });
+  if (res.ok) {
+    const data = await res.json();
+    syllabusCache.value = new Map(syllabusCache.value).set(joinCode, data);
+  } else {
+    syllabusCache.value = new Map(syllabusCache.value).set(joinCode, null);
+  }
+}
+
+function weekStartForIndex(i) {
+  return addDays(startOfWeekSunday(new Date()), i * 7);
+}
+
+function weekEndForIndex(i) {
+  return endOfWeekSaturday(weekStartForIndex(i));
+}
+
+const selectedWeekStart = computed(() => weekStartForIndex(weekIndex.value));
+const selectedWeekEnd = computed(() => weekEndForIndex(weekIndex.value));
+
+function fmtRange(start, end) {
+  const a = start.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  const b = end.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return `${a} – ${b}`;
+}
+
+const weekOptions = computed(() => {
+  const out = [];
+  for (let i = 0; i < 8; i++) {
+    out.push({
+      value: i,
+      label: `${i === 0 ? "This week" : `Week +${i}`} · ${fmtRange(weekStartForIndex(i), weekEndForIndex(i))}`,
+    });
+  }
+  return out;
+});
+
+function inSelectedWeek(dt) {
+  return dt >= selectedWeekStart.value && dt <= selectedWeekEnd.value;
+}
+
+// All iCal events returned by the backend are treated as workload items.
+// (We only exclude cancelled events.)
+const workloadEvents = computed(() => events.value.filter((e) => !e.isCancelled));
+
+const overallCount = computed(() =>
+  workloadEvents.value.filter((e) => inSelectedWeek(parseLocalDateTime(e.startAt))).length
+);
+
+const overallLevel = computed(() => workloadLevelFromCount(overallCount.value));
+
+const overallMeterWidth = computed(() => Math.min(100, (overallCount.value / 8) * 100));
+
+function classCodeForJoinCode(joinCode) {
+  const c = myClasses.value.find((x) => x.joinCode === joinCode);
+  return String(c?.classCode || "").toUpperCase() || null;
+}
+
+function eventsForClassThisWeek(joinCode) {
+  const code = classCodeForJoinCode(joinCode);
+  if (!code) return [];
+
+  return workloadEvents.value
+    .filter((e) => {
+      const dt = parseLocalDateTime(e.startAt);
+      if (!inSelectedWeek(dt)) return false;
+      const matched = matchEventToClassCode(e.summary, myClasses.value);
+      return matched === code;
+    })
+    .sort((a, b) => parseLocalDateTime(a.startAt) - parseLocalDateTime(b.startAt));
+}
+
+function gradeBreakdownForJoinCode(joinCode) {
+  const syllabus = syllabusCache.value.get(joinCode);
+  const gb = syllabus?.gradeBreakdown;
+  return Array.isArray(gb) ? gb : [];
+}
+
+function weightBadgeForEvent(joinCode, summary) {
+  const gb = gradeBreakdownForJoinCode(joinCode);
+  const matched = matchGradeBreakdownComponent(summary, gb);
+  if (!matched) return null;
+  const comp = matched.component || "";
+  const w = matched.weight || "";
+  if (!comp && !w) return null;
+  return `${comp}${comp && w ? " · " : ""}${w}`;
+}
+
+function eventKey(e) {
+  return `${e.icalUid || ""}|${e.startAt || ""}|${e.recurrenceId || ""}`;
+}
+
+async function toggleClass(joinCode) {
+  open[joinCode] = !open[joinCode];
+  if (open[joinCode]) {
+    await fetchSyllabusIfNeeded(joinCode);
+  }
+}
+
+onMounted(async () => {
+  loading.value = true;
+  error.value = "";
+  try {
+    await Promise.all([fetchMyClasses(), fetchEvents()]);
+  } catch (e) {
+    error.value = e?.message || "Failed to load workload projections";
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <div class="wrap">
+    <div class="topbar">
+      <div>
+        <h1>Workload Projections</h1>
+        <p class="muted">Counts are based on Canvas iCal due items (Sunday–Saturday).</p>
+      </div>
+
+      <select class="select" v-model.number="weekIndex">
+        <option v-for="o in weekOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
+      </select>
+    </div>
+
+    <div v-if="error" class="note err">{{ error }}</div>
+
+    <div class="grid">
+      <!-- Overall -->
+      <section class="card">
+        <div class="card-header">
+          <div>
+            <h2>Overall Workload</h2>
+            <p class="muted">{{ overallCount }} assignment(s) due · {{ fmtRange(selectedWeekStart, selectedWeekEnd) }}</p>
+          </div>
+          <span class="pill" :class="overallLevel">{{ overallLevel }}</span>
+        </div>
+
+        <div class="workload-scale">
+          <span class="pill heavy">Heavy</span>
+          <span class="pill moderate">Moderate</span>
+          <span class="pill light">Light</span>
+        </div>
+
+        <div class="workload-meter" aria-hidden="true">
+          <div class="workload-meter-fill" :class="overallLevel" :style="{ width: overallMeterWidth + '%' }" />
+        </div>
+
+        <div class="empty-note">
+          {{ overallCount ? `Workload level: ${overallLevel}.` : 'No due assignments detected for this week.' }}
+        </div>
+      </section>
+
+      <!-- Per-class -->
+      <section class="card">
+        <div class="card-header">
+          <div>
+            <h2>By Class</h2>
+            <p class="muted">Toggle a class to see due items and their grade weight (from the syllabus breakdown).</p>
+          </div>
+        </div>
+
+        <div v-if="loading" class="placeholder">Loading…</div>
+        <div v-else-if="!myClasses.length" class="placeholder">
+          <p class="muted" style="margin:0">No classes found.</p>
+        </div>
+
+        <div v-else class="class-list">
+          <div class="class-block" v-for="c in myClasses" :key="c.joinCode">
+            <button class="toggle" @click="toggleClass(c.joinCode)">
+              <div>
+                <div class="class-code">{{ c.classCode }}</div>
+                <div class="class-sub">{{ c.quarter }} {{ c.year }}</div>
+              </div>
+              <div class="toggle-right">
+                <span class="count">{{ eventsForClassThisWeek(c.joinCode).length }}</span>
+                <span class="chev">{{ open[c.joinCode] ? '−' : '+' }}</span>
+              </div>
+            </button>
+
+            <div v-if="open[c.joinCode]" class="panel">
+              <div v-if="syllabusCache.has(c.joinCode) && syllabusCache.get(c.joinCode) === null" class="placeholder">
+                <p class="muted" style="margin:0">No syllabus uploaded yet for this course.</p>
+              </div>
+
+              <div v-else>
+                <div class="subcard" v-if="gradeBreakdownForJoinCode(c.joinCode).length">
+                  <div class="subhead">Grade breakdown</div>
+                  <div class="breakdown-row" v-for="(item, i) in gradeBreakdownForJoinCode(c.joinCode)" :key="i">
+                    <span class="breakdown-name">{{ item.component }}</span>
+                    <span class="breakdown-weight">{{ item.weight }}</span>
+                  </div>
+                </div>
+
+                <div class="subcard">
+                  <div class="subhead">Due this week · {{ fmtRange(selectedWeekStart, selectedWeekEnd) }}</div>
+
+                  <div v-if="eventsForClassThisWeek(c.joinCode).length" class="items">
+                    <div class="item" v-for="e in eventsForClassThisWeek(c.joinCode)" :key="eventKey(e)">
+                      <div class="item-title">{{ e.summary || '(No title)' }}</div>
+                      <div class="item-sub">
+                        <span class="chip">Due {{ parseLocalDateTime(e.startAt).toLocaleString(undefined, { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }) }}</span>
+                        <span class="chip" v-if="weightBadgeForEvent(c.joinCode, e.summary)">
+                          {{ weightBadgeForEvent(c.joinCode, e.summary) }}
+                        </span>
+                        <span class="chip muted" v-else>Weight: —</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div v-else class="placeholder">
+                    <p class="muted" style="margin:0">No due assignments detected for this class this week.</p>
+                  </div>
+                </div>
+
+                <div class="note small">
+                  If your syllabus only provides category weights (e.g., “Assignments 60%”), we show that category weight for each matched item. Exact per-assignment % typically requires point totals or explicit per-assignment grading.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.wrap { color: #e5e7eb; }
+
+.topbar {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+h1 { margin: 0; font-size: 22px; }
+h2 { margin: 0; font-size: 18px; }
+
+.muted { margin: 6px 0 0; color: #9ca3af; font-size: 13px; }
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+
+@media (max-width: 980px) {
+  .grid { grid-template-columns: 1fr; }
+}
+
+.card {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 18px;
+  padding: 16px;
+  box-shadow: 0 18px 40px rgba(0,0,0,0.25);
+}
+
+.card-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.select {
+  border: 1px solid rgba(255,255,255,0.10);
+  background: rgba(255,255,255,0.04);
+  color: #e5e7eb;
+  padding: 10px 12px;
+  border-radius: 14px;
+}
+
+.workload-scale {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0.2px;
+  border: 1px solid rgba(255,255,255,0.10);
+  background: rgba(255,255,255,0.04);
+  color: #e5e7eb;
+  text-transform: capitalize;
+}
+
+.pill.heavy {
+  background: rgba(239, 68, 68, 0.18);
+  border-color: rgba(239, 68, 68, 0.35);
+  color: rgba(254, 202, 202, 0.95);
+}
+
+.pill.moderate {
+  background: rgba(245, 158, 11, 0.16);
+  border-color: rgba(245, 158, 11, 0.32);
+  color: rgba(253, 230, 138, 0.95);
+}
+
+.pill.light {
+  background: rgba(34, 197, 94, 0.16);
+  border-color: rgba(34, 197, 94, 0.30);
+  color: rgba(187, 247, 208, 0.95);
+}
+
+.workload-meter {
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.08);
+  overflow: hidden;
+  margin-bottom: 12px;
+}
+
+.workload-meter-fill { height: 100%; border-radius: 999px; background: rgba(255,255,255,0.10); }
+
+.workload-meter-fill.heavy {
+  background: linear-gradient(90deg, rgba(239, 68, 68, 0.65), rgba(239, 68, 68, 0.25));
+}
+.workload-meter-fill.moderate {
+  background: linear-gradient(90deg, rgba(245, 158, 11, 0.65), rgba(245, 158, 11, 0.25));
+}
+.workload-meter-fill.light {
+  background: linear-gradient(90deg, rgba(34, 197, 94, 0.65), rgba(34, 197, 94, 0.25));
+}
+
+.placeholder {
+  padding: 14px;
+  border-radius: 16px;
+  background: rgba(255,255,255,0.03);
+  border: 1px dashed rgba(255,255,255,0.10);
+}
+
+.empty-note {
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(255,255,255,0.03);
+  border: 1px dashed rgba(255,255,255,0.10);
+  font-size: 13px;
+  color: #9ca3af;
+  font-weight: 800;
+}
+
+.note {
+  padding: 10px 12px;
+  border-radius: 14px;
+  margin-bottom: 12px;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.note.small {
+  margin-top: 12px;
+  font-weight: 700;
+  color: #9ca3af;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+}
+
+.note.err {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  color: rgba(254, 202, 202, 0.95);
+}
+
+.class-list { display: flex; flex-direction: column; gap: 12px; }
+
+.class-block {
+  border-radius: 16px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  overflow: hidden;
+}
+
+.toggle {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 12px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.toggle:hover { background: rgba(255,255,255,0.04); }
+
+.toggle-right { display: flex; align-items: center; gap: 10px; }
+
+.count {
+  font-size: 12px;
+  font-weight: 1000;
+  padding: 6px 9px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+}
+
+.chev { font-weight: 1000; font-size: 16px; width: 16px; text-align: center; }
+
+.class-code { font-weight: 900; color: #e5e7eb; }
+.class-sub { margin-top: 4px; color: #9ca3af; font-size: 12px; font-weight: 800; }
+
+.panel { padding: 12px; border-top: 1px solid rgba(255,255,255,0.06); }
+
+.subcard {
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  margin-bottom: 12px;
+}
+
+.subhead {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6b7280;
+  margin-bottom: 10px;
+}
+
+.breakdown-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  font-size: 13px;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+
+.breakdown-row:last-child { border-bottom: none; }
+
+.breakdown-name { color: #e5e7eb; font-weight: 800; }
+
+.breakdown-weight { color: #9ca3af; font-weight: 900; }
+
+.items { display: flex; flex-direction: column; gap: 10px; }
+
+.item {
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+}
+
+.item-title { font-weight: 900; }
+
+.item-sub { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 8px; }
+
+.chip {
+  font-size: 12px;
+  font-weight: 900;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  color: #e5e7eb;
+}
+
+.chip.muted { color: #9ca3af; }
+</style>

--- a/frontend-vue/src/views/WorkloadProjections.vue
+++ b/frontend-vue/src/views/WorkloadProjections.vue
@@ -1,6 +1,9 @@
 <script setup>
-import { computed, onMounted, reactive, ref } from "vue";
 
+// good-ol vue imports
+import { computed, onMounted, reactive, ref } from "vue"; 
+
+// utility functions from src/utils/workload.js
 import {
   addDays,
   endOfWeekSaturday,
@@ -11,6 +14,7 @@ import {
   workloadLevelFromCount,
 } from "../utils/workload";
 
+// ---- ref varaibles for classes ---
 const loading = ref(false);
 const error = ref("");
 
@@ -19,23 +23,26 @@ const events = ref([]);
 
 const weekIndex = ref(0); // 0 = this week
 
-// toggle state per joinCode
+// ---- reactive state for which class panels are open ----
 const open = reactive({});
 
 const syllabusCache = ref(new Map()); // joinCode -> syllabusObject|null
 
+// ---- fetching classes from current user ----
 async function fetchMyClasses() {
   const res = await fetch("/api/classes/mine", { credentials: "include" });
   if (!res.ok) throw new Error("Failed to load classes");
   myClasses.value = await res.json();
 }
 
+// ---- fetching calendar events from current user ----
 async function fetchEvents() {
   const res = await fetch("/api/calendar/events", { credentials: "include" });
   if (!res.ok) throw new Error("Failed to load calendar events");
   events.value = await res.json();
 }
 
+/// ---- fetching syllabus for a class, if we haven't already ----
 async function fetchSyllabusIfNeeded(joinCode) {
   if (!joinCode) return;
   if (syllabusCache.value.has(joinCode)) return;
@@ -49,23 +56,28 @@ async function fetchSyllabusIfNeeded(joinCode) {
   }
 }
 
+// calculates the start date for that week index (0 = this week, 1 = next week, etc)
 function weekStartForIndex(i) {
   return addDays(startOfWeekSunday(new Date()), i * 7);
 }
 
+// calculates the end date for that week index (0 = this week, 1 = next week, etc)
 function weekEndForIndex(i) {
   return endOfWeekSaturday(weekStartForIndex(i));
 }
 
+// computed properties for the selected week's start and end dates, based on the current weekIndex
 const selectedWeekStart = computed(() => weekStartForIndex(weekIndex.value));
 const selectedWeekEnd = computed(() => weekEndForIndex(weekIndex.value));
 
+// formats a date range (e.g. "Mar 5 – Mar 11") for display in the UI
 function fmtRange(start, end) {
   const a = start.toLocaleDateString(undefined, { month: "short", day: "numeric" });
   const b = end.toLocaleDateString(undefined, { month: "short", day: "numeric" });
   return `${a} – ${b}`;
 }
 
+// options for the week selection dropdown, showing the date range for each week
 const weekOptions = computed(() => {
   const out = [];
   for (let i = 0; i < 8; i++) {
@@ -77,27 +89,90 @@ const weekOptions = computed(() => {
   return out;
 });
 
+// helper function to check if a given date falls within the currently selected week
 function inSelectedWeek(dt) {
   return dt >= selectedWeekStart.value && dt <= selectedWeekEnd.value;
 }
 
 // All iCal events returned by the backend are treated as workload items.
-// (We only exclude cancelled events.)
 const workloadEvents = computed(() => events.value.filter((e) => !e.isCancelled));
 
+// Overall workload level for the selected week, based on the count of due items.
 const overallCount = computed(() =>
   workloadEvents.value.filter((e) => inSelectedWeek(parseLocalDateTime(e.startAt))).length
 );
 
+// Maps the overall count to a workload level (e.g. "light", "moderate", "heavy") for UI display.
 const overallLevel = computed(() => workloadLevelFromCount(overallCount.value));
 
+// Calculates the width of the workload meter bar as a percentage, capping at 100% for 8 or more items.
 const overallMeterWidth = computed(() => Math.min(100, (overallCount.value / 8) * 100));
 
+/*monthly overview calculations*/
+const monthStart = computed(() => {
+  const d = new Date();
+  const out = new Date(d.getFullYear(), d.getMonth(), 1);
+  out.setHours(0, 0, 0, 0);
+  return out;
+});
+
+const monthEnd = computed(() => {
+  const d = new Date();
+  const out = new Date(d.getFullYear(), d.getMonth() + 1, 0);
+  out.setHours(23, 59, 59, 999);
+  return out;
+});
+
+const monthLabel = computed(() =>
+  monthStart.value.toLocaleDateString(undefined, { month: "long", year: "numeric" })
+);
+
+const monthWeeks = computed(() => {
+  const start = startOfWeekSunday(monthStart.value);
+  const end = endOfWeekSaturday(monthEnd.value);
+  const out = [];
+
+  for (let ws = new Date(start); ws <= end; ws = addDays(ws, 7)) {
+    const we = endOfWeekSaturday(ws);
+    const wsCopy = new Date(ws);
+    const weCopy = new Date(we);
+    const labelStart = wsCopy.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    const labelEnd = weCopy.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    const count = workloadEvents.value.filter((e) => {
+      const dt = parseLocalDateTime(e.startAt);
+      return dt >= wsCopy && dt <= weCopy;
+    }).length;
+    const level = workloadLevelFromCount(count);
+
+    out.push({
+      start: wsCopy,
+      end: weCopy,
+      count,
+      level,
+      labelStart,
+      labelEnd,
+    });
+  }
+
+  return out;
+});
+
+// Fixed chart scale so bars stay readable
+const MONTH_CHART_MAX = 10;
+
+// Calculates the height percentage for a bar in the monthly overview chart, capping at MONTH_CHART_MAX for readability.
+function monthBarHeightPct(count) {
+  const capped = Math.min(MONTH_CHART_MAX, Math.max(0, Number(count) || 0));
+  return (capped / MONTH_CHART_MAX) * 100;
+}
+
+// Helper function to get the class code (e.g. "CSCD350") for a given join code, by looking it up in the user's classes.
 function classCodeForJoinCode(joinCode) {
   const c = myClasses.value.find((x) => x.joinCode === joinCode);
   return String(c?.classCode || "").toUpperCase() || null;
 }
 
+// Gets the calendar events for a specific class (identified by join code)
 function eventsForClassThisWeek(joinCode) {
   const code = classCodeForJoinCode(joinCode);
   if (!code) return [];
@@ -112,12 +187,15 @@ function eventsForClassThisWeek(joinCode) {
     .sort((a, b) => parseLocalDateTime(a.startAt) - parseLocalDateTime(b.startAt));
 }
 
+// Helper function to get the grade breakdown array for a given class (identified by join code) from the syllabus cache.
 function gradeBreakdownForJoinCode(joinCode) {
   const syllabus = syllabusCache.value.get(joinCode);
   const gb = syllabus?.gradeBreakdown;
   return Array.isArray(gb) ? gb : [];
 }
 
+// Helper function to generate a badge string showing the grade component and weight for a calendar event,
+//  by matching the event summary to the syllabus grade breakdown.
 function weightBadgeForEvent(joinCode, summary) {
   const gb = gradeBreakdownForJoinCode(joinCode);
   const matched = matchGradeBreakdownComponent(summary, gb);
@@ -128,10 +206,14 @@ function weightBadgeForEvent(joinCode, summary) {
   return `${comp}${comp && w ? " · " : ""}${w}`;
 }
 
+/* Helper function to generate a unique key for a calendar event, based on its iCal UID, start time, and recurrence ID.
+   We need this to ensure that events are rendered correctly with v-for loops */
 function eventKey(e) {
   return `${e.icalUid || ""}|${e.startAt || ""}|${e.recurrenceId || ""}`;
 }
 
+// Toggles whether the details panel for a class (identified by join code) is open, 
+// and if opening, fetches the syllabus if we haven't already.
 async function toggleClass(joinCode) {
   open[joinCode] = !open[joinCode];
   if (open[joinCode]) {
@@ -139,6 +221,7 @@ async function toggleClass(joinCode) {
   }
 }
 
+// On component mount, fetch the user's classes and calendar events in parallel, and handle loading and error states.
 onMounted(async () => {
   loading.value = true;
   error.value = "";
@@ -160,7 +243,7 @@ onMounted(async () => {
         <p class="muted">Counts are based on Canvas iCal due items (Sunday–Saturday).</p>
       </div>
 
-      <select class="select" v-model.number="weekIndex">
+      <select class="select" :class="{ primary: weekIndex === 0 }" v-model.number="weekIndex">
         <option v-for="o in weekOptions" :key="o.value" :value="o.value">{{ o.label }}</option>
       </select>
     </div>
@@ -168,11 +251,12 @@ onMounted(async () => {
     <div v-if="error" class="note err">{{ error }}</div>
 
     <div class="grid">
-      <!-- Overall -->
+
+      <!-- Workload This Week-->
       <section class="card">
         <div class="card-header">
           <div>
-            <h2>Overall Workload</h2>
+            <h2>Workload This Week</h2>
             <p class="muted">{{ overallCount }} assignment(s) due · {{ fmtRange(selectedWeekStart, selectedWeekEnd) }}</p>
           </div>
           <span class="pill" :class="overallLevel">{{ overallLevel }}</span>
@@ -188,12 +272,10 @@ onMounted(async () => {
           <div class="workload-meter-fill" :class="overallLevel" :style="{ width: overallMeterWidth + '%' }" />
         </div>
 
-        <div class="empty-note">
-          {{ overallCount ? `Workload level: ${overallLevel}.` : 'No due assignments detected for this week.' }}
-        </div>
+        <div v-if="!overallCount" class="empty-note">No due assignments detected for this week.</div>
       </section>
 
-      <!-- Per-class -->
+      <!-- Per-class Cards -->
       <section class="card">
         <div class="card-header">
           <div>
@@ -256,10 +338,31 @@ onMounted(async () => {
                 </div>
 
                 <div class="note small">
-                  If your syllabus only provides category weights (e.g., “Assignments 60%”), we show that category weight for each matched item. Exact per-assignment % typically requires point totals or explicit per-assignment grading.
+                 Note: Weight shown is the syllabus category weight, not this item’s exact grade impact.
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Monthly overview (Bar Chart) -->
+      <section class="card">
+        <div class="card-header">
+          <div>
+            <h2>{{ monthLabel }}</h2>
+            <p class="muted">Weekly due Assignments (Sun–Sat).</p>
+          </div>
+        </div>
+
+        <div v-if="loading" class="placeholder">Loading…</div>
+        <div v-else-if="!workloadEvents.length" class="empty-note">No due assignments detected for this month.</div>
+
+        <div v-else class="bar-chart" role="img" :aria-label="`${monthLabel} weekly due items bar chart`">
+          <div class="bar-col" v-for="(w, i) in monthWeeks" :key="i" :title="`${fmtRange(w.start, w.end)} · ${w.count} due item(s)`">
+            <div class="bar" :class="w.level" :style="{ height: monthBarHeightPct(w.count) + '%' }" />
+            <div class="bar-count">{{ w.count }}</div>
+            <div class="bar-label">{{ w.labelStart }} - {{ w.labelEnd }}</div>
           </div>
         </div>
       </section>
@@ -285,12 +388,8 @@ h2 { margin: 0; font-size: 18px; }
 
 .grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr;
   gap: 18px;
-}
-
-@media (max-width: 980px) {
-  .grid { grid-template-columns: 1fr; }
 }
 
 .card {
@@ -315,6 +414,15 @@ h2 { margin: 0; font-size: 18px; }
   color: #e5e7eb;
   padding: 10px 12px;
   border-radius: 14px;
+  cursor: pointer;
+}
+
+.select.primary {
+  background: #2563eb;
+  border-color: #1d4ed8;
+  color: #ffffff;
+  font-weight: 800;
+  border-radius: 999px;
 }
 
 .workload-scale {
@@ -327,7 +435,7 @@ h2 { margin: 0; font-size: 18px; }
 .pill {
   display: inline-flex;
   align-items: center;
-  padding: 6px 10px;
+  padding: 10px 10px;
   border-radius: 999px;
   font-size: 12px;
   font-weight: 900;
@@ -357,7 +465,7 @@ h2 { margin: 0; font-size: 18px; }
 }
 
 .workload-meter {
-  height: 12px;
+  height: 14px;
   border-radius: 999px;
   background: rgba(255,255,255,0.05);
   border: 1px solid rgba(255,255,255,0.08);
@@ -392,6 +500,63 @@ h2 { margin: 0; font-size: 18px; }
   font-size: 13px;
   color: #9ca3af;
   font-weight: 800;
+}
+
+.bar-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  height: 150px;
+  padding: 8px 4px;
+}
+
+.bar-col {
+  flex: 1;
+  min-width: 32px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.bar {
+  width: 100%;
+  max-width: 46px;
+  min-height: 4px;
+  border-radius: 12px;
+  background: rgba(255,255,255,0.10);
+  border: 1px solid rgba(255,255,255,0.10);
+}
+
+.bar.heavy {
+  background: rgba(239, 68, 68, 0.22);
+  border-color: rgba(239, 68, 68, 0.35);
+}
+
+.bar.moderate {
+  background: rgba(245, 158, 11, 0.20);
+  border-color: rgba(245, 158, 11, 0.32);
+}
+
+.bar.light {
+  background: rgba(34, 197, 94, 0.20);
+  border-color: rgba(34, 197, 94, 0.30);
+}
+
+.bar-count {
+  font-size: 12px;
+  font-weight: 900;
+  color: #e5e7eb;
+}
+
+.bar-label {
+  font-size: 10px;
+  font-weight: 800;
+  color: #9ca3af;
+  line-height: 1.1;
+  text-align: center;
 }
 
 .note {


### PR DESCRIPTION
Workload Projection Page
- Monthly weekly bar chart to show amount of workload for each week
- General Workload projection shows the amount of events/assignments shown for the week
- Shows the assignment for each class that is due that specific week, assignees a weight grade percentage (For now its just what the category percentage it falls under is, not the actual percentage), if there is no connection ex (Capstone due June 3 -> No Grade weight that falls under that name or synonym keywords) it will just not have a graded weight

Can still improve this a bit but I think we can start trying to get some features we haven't done yet. 

Files which were changed quite a bit:
- *NEW* WorkloadProjection.vue
- Dashboard.vue
- *NEW* Workload.js 