### PR TITLE
Flag Set up

### DIFF
--- a/.github/workflows/main_syllabussync.yml
+++ b/.github/workflows/main_syllabussync.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install and build Vue
         working-directory: frontend-vue
+        env:
+          VITE_SYLLABUS_IMPORT_ENABLED: "false"
         run: |
           npm ci
           npm run build
@@ -96,6 +98,15 @@ jobs:
           client-id: ${{ secrets.AZUREAPPSERVICE_CLIENTID_EF2E571B217646A98C92CCD138B91672 }}
           tenant-id: ${{ secrets.AZUREAPPSERVICE_TENANTID_446BC23E295B41A08802B992CCEBD962 }}
           subscription-id: ${{ secrets.AZUREAPPSERVICE_SUBSCRIPTIONID_0BA6463238AF42BFAF8DA82F5559C523 }}
+
+      - name: Set production feature flags
+        uses: azure/CLI@v2
+        with:
+          inlineScript: |
+            RG=$(az webapp show --name syllabussync --query resourceGroup -o tsv)
+            az webapp config appsettings set --name syllabussync --resource-group "$RG" --settings SYLLABUS_IMPORT_ENABLED="$SYLLABUS_IMPORT_ENABLED"
+        env:
+          SYLLABUS_IMPORT_ENABLED: "false"
 
       - name: Deploy to Azure Web App
         uses: azure/webapps-deploy@v3

--- a/backend-springboot/src/main/java/com/cscd488seniorproject/syllabussyncproject/controllers/AuthController.java
+++ b/backend-springboot/src/main/java/com/cscd488seniorproject/syllabussyncproject/controllers/AuthController.java
@@ -121,5 +121,6 @@ public class AuthController {
     // This record class is used to represent the response from the /me endpoint, which includes the user's email, role, first name, and last name. 
     // Inline suggestions suggested making this a record.
     public record MeResponse(String email, String role, String firstName, String lastName) {}
-
 }
+
+

--- a/backend-springboot/src/main/java/com/cscd488seniorproject/syllabussyncproject/controllers/SyllabusController.java
+++ b/backend-springboot/src/main/java/com/cscd488seniorproject/syllabussyncproject/controllers/SyllabusController.java
@@ -8,6 +8,8 @@ import com.cscd488seniorproject.syllabussyncproject.service.ClaudeService;
 import com.cscd488seniorproject.syllabussyncproject.service.SyllabusService;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -26,6 +28,11 @@ public class SyllabusController {
     private final SyllabusService syllabusService;
     private final UserAccountRepository userAccountRepository;
 
+    // Feature flag to prevent spending AI credits in production.
+    // Set `SYLLABUS_IMPORT_ENABLED=false` in Azure to disable parsing.
+    @Value("${SYLLABUS_IMPORT_ENABLED:true}")
+    private boolean syllabusImportEnabled;
+
     /**
      * POST /api/courses/{courseId}/syllabus/parse
      * Accepts the raw PDF as multipart/form-data, base64-encodes it, sends it to
@@ -37,6 +44,11 @@ public class SyllabusController {
     public ResponseEntity<?> parse(
             @RequestParam("file") MultipartFile file) {
         try {
+            if (!syllabusImportEnabled) {
+                return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                        .body("Syllabus import is temporarily disabled");
+            }
+
             if (file == null || file.isEmpty()) {
                 return ResponseEntity.badRequest().body("PDF file is required");
             }

--- a/frontend-vue/src/components/Sidebar.vue
+++ b/frontend-vue/src/components/Sidebar.vue
@@ -16,17 +16,24 @@ This is basically a local variable that based on the user's role, will render th
 */
 const normalizedRole = computed(() => (props.role || "STUDENT").trim().toUpperCase()); 
 
+const syllabusImportEnabled = (import.meta.env.VITE_SYLLABUS_IMPORT_ENABLED || "true").toString().toLowerCase() !== "false";
+
 const links = computed(() => {
   if (normalizedRole.value === 'PROFESSOR') {
-    return [
+    const base = [
       { to: "/app", label: "Dashboard" },
       { to: "/app/classes", label: "My Classes" },
       { to: "/app/meetings", label: "Meeting Times" },
       { to: "/app/calendar", label: "Calendar" },
-      { to: "/app/syllabus-upload", label: "Syllabus Upload" },
       { to: "/app/workload-projections", label: "Workload Projections" },
       { to: "/app/my-office-hours", label: "My Office Hours" },
     ];
+
+    if (syllabusImportEnabled) {
+      base.splice(4, 0, { to: "/app/syllabus-upload", label: "Syllabus Upload" });
+    }
+
+    return base;
   }
 
   if (normalizedRole.value === 'TA') {

--- a/frontend-vue/src/router/index.js
+++ b/frontend-vue/src/router/index.js
@@ -14,6 +14,8 @@ import MyClasses from "../views/MyClasses.vue";
 import OfficeHours from "../views/newofficehours.vue";
 import ClassDetails from "../views/ClassDetails.vue";
 
+const syllabusImportEnabled = (import.meta.env.VITE_SYLLABUS_IMPORT_ENABLED || "true").toString().toLowerCase() !== "false";
+
 const router = createRouter({
   history: createWebHistory(),
   routes: [
@@ -43,6 +45,11 @@ const router = createRouter({
 // This navigation guard checks if the route requires authentication and verifies the user's session by making a request to the backend.
 //  If the user is not authenticated, they are redirected to the login page.
 router.beforeEach(async (to, from, next) => {
+  if (to.name === 'syllabus-upload' && !syllabusImportEnabled) {
+    next('/app');
+    return;
+  }
+
   if (to.meta.requiresAuth) {
     try {
       const res = await fetch('/api/check-auth', {

--- a/frontend-vue/src/views/ClassDetails.vue
+++ b/frontend-vue/src/views/ClassDetails.vue
@@ -33,6 +33,8 @@ const addTaSuccess = ref("");
 
 const syllabusOpen = ref(false);
 
+const syllabusImportEnabled = (import.meta.env.VITE_SYLLABUS_IMPORT_ENABLED || "true").toString().toLowerCase() !== "false";
+
 const rosterTAs = computed(() => rosterUsers.value.filter(u => (u?.role || "").toString().toUpperCase() === "TA"));
 const rosterStudents = computed(() => rosterUsers.value.filter(u => (u?.role || "").toString().toUpperCase() === "STUDENT"));
 
@@ -235,7 +237,7 @@ watch(joinCode, async () => {
         </div>
       </div>
 
-      <div class="section">
+      <div v-if="syllabusImportEnabled" class="section">
         <div class="section-title">Syllabus</div>
         <button class="btn ghost" type="button" @click="toggleSyllabus">
           {{ syllabusOpen ? "Hide syllabus upload" : "Manage syllabus" }}

--- a/frontend-vue/src/views/SyllabusUpload.vue
+++ b/frontend-vue/src/views/SyllabusUpload.vue
@@ -9,10 +9,17 @@
     </div>
 
     <template v-else>
-      <div class="uploader-header">
-        <h1>Syllabus Upload</h1>
-        <span class="role-badge">Professor</span>
+      <div v-if="!syllabusImportEnabled" class="role-gate">
+        <div class="role-gate__icon">🔒</div>
+        <p class="role-gate__msg">Syllabus import is disabled.</p>
+        <p class="role-gate__sub">This is turned off in production to prevent credit usage.</p>
       </div>
+
+      <template v-else>
+        <div class="uploader-header">
+          <h1>Syllabus Upload</h1>
+          <span class="role-badge">Professor</span>
+        </div>
 
       <!-- Step 0: Select class (standalone mode — no courseId prop) -->
       <div v-if="step === 'select'" class="select-step">
@@ -301,17 +308,18 @@
         </div>
       </div>
 
-      <!-- Step 3: Saved -->
-      <div v-if="step === 'saved'" class="saved-state">
-        <div class="saved-state__icon">✓</div>
-        <h3 class="saved-state__title">Syllabus saved</h3>
-        <p class="saved-state__sub">Students enrolled in this course can now view the syllabus information.</p>
-        <p v-if="meetingNotice" class="saved-state__meeting-notice" :class="{ 'notice--warn': !savedMeetingCount }">
-          {{ meetingNotice }}
-        </p>
-        <button class="btn-ghost" @click="resetToUpload">Upload another</button>
-      </div>
+        <!-- Step 3: Saved -->
+        <div v-if="step === 'saved'" class="saved-state">
+          <div class="saved-state__icon">✓</div>
+          <h3 class="saved-state__title">Syllabus saved</h3>
+          <p class="saved-state__sub">Students enrolled in this course can now view the syllabus information.</p>
+          <p v-if="meetingNotice" class="saved-state__meeting-notice" :class="{ 'notice--warn': !savedMeetingCount }">
+            {{ meetingNotice }}
+          </p>
+          <button class="btn-ghost" @click="resetToUpload">Upload another</button>
+        </div>
 
+      </template>
     </template>
 
     <!-- Create class popup (standalone mode) -->
@@ -369,6 +377,8 @@ const emit = defineEmits(['saved'])
 
 const isProfessor = computed(() => props.userRole === 'professor')
 
+const syllabusImportEnabled = (import.meta.env.VITE_SYLLABUS_IMPORT_ENABLED || 'true').toString().toLowerCase() !== 'false'
+
 // When no courseId prop is provided, we're in standalone (route) mode and need class selection
 const standaloneMode = computed(() => !props.courseId)
 const effectiveCourseId = computed(() => props.courseId || selectedClassId.value)
@@ -410,6 +420,7 @@ const lowConfidenceCount = computed(() => {
 })
 
 onMounted(() => {
+  if (!syllabusImportEnabled) return
   if (standaloneMode.value && isProfessor.value) fetchMyClasses()
   else if (props.courseId) loadExistingSyllabus()
 })
@@ -575,6 +586,10 @@ function ensureDefaults(parsed) {
 }
 
 async function parseSyllabus() {
+  if (!syllabusImportEnabled) {
+    error.value = 'Syllabus import is disabled.'
+    return
+  }
   if (!pdfFile.value) return
   loading.value = true
   error.value   = ''


### PR DESCRIPTION
PR: Disable Syllabus Import/Parsing in Production (Credit-Safe Deployment, Hopefully)

Why? Por que?

The syllabus “Extract & review” flow calls Anthropic/Claude and can spend credits.
Hiding buttons in the UI isn’t enough as anyone (including bots) can still call the backend endpoint directly.

This PR adds a server-side feature flag to hard-disable parsing in production, plus a UI hide/guard so professors don’t see or accidentally use the feature when it’s disabled.